### PR TITLE
Mo heroku support

### DIFF
--- a/snorkel/Procfile
+++ b/snorkel/Procfile
@@ -1,0 +1,1 @@
+web: node app.js

--- a/snorkel/config/heroku.js
+++ b/snorkel/config/heroku.js
@@ -1,0 +1,36 @@
+module.exports = {
+  sockets: true,
+  ssl: false,
+  udp: {
+    port: 59036
+  },
+  authorized_users: "config/users.htpasswd",
+  superuser: {
+    "admin" : true
+  },
+
+  // setting to true will make the UDP collector and the web server run as
+  // different processes, for stability reasons
+  separate_services: false,
+  http_port: process.env.PORT || 3000,
+  max_http_sockets: 1000,
+  max_https_sockets: 1000,
+  require_https: false,
+  backend: {
+    driver: "mongo",
+    db_url: process.env.MONGOHQ_URL
+  },
+  hostname: process.env.HTTPHOST || "localhost",
+  no_api_auth: true, // require user authentication to use API endpoint
+  google_auth: {
+    enabled: true,
+    require_domain: process.env.GPLUS_DOMAIN,
+  },
+  behind_proxy: true,
+  rss_feed: {
+    url: null
+  },
+  // This is the default max data size of the collection. Each dataset will
+  // only grow to this size and no further, ideally
+  default_max_dataset_size: process.env.MAX_DATASET_SIZE || 1024 * 1024 * 100 // 100 MB
+};

--- a/snorkel/core/server/session.js
+++ b/snorkel/core/server/session.js
@@ -1,14 +1,16 @@
 "use strict";
 
+var config = require('./config');
 var express = require('express');
 var MongoStore = require('connect-mongo')(express);
 
 var _store, _session;
 
 var SESSION_SECRET = 'keyboard cat';
+
 module.exports = {
   install: function(app) {
-    _store = new MongoStore({ db: 'jank' } );
+    _store = new MongoStore({url: config.backend.db_url, db: 'jank' } );
     _session = express.session({
         secret: SESSION_SECRET,
         store: _store


### PR DESCRIPTION
This completes the basic heroku deployment support.  The bugfix is the minor change to session.js, the other file is the config template.  Here is the useful info on getting this to work on heroku:
## Heroku instructions.
1. create an app (**heroku apps:create snorkelista**, for example)
2. set environment variables on heroku for the app:
   1. heroku config:add MONGOHQ_URL=mongodb://user:pwd@host:port/db
   2. heroku config:add ENV=heroku.js
   3. heroku config:add HTTPHOST=snorkelista.herokuapp.com (or whatever you use)
   4. heroku config:add GPLUS_DOMAIN=yourcompanydomain.com (or change heroku.js to configure auth)
3. push everything under the snorkel directory (in particular the Procfile) to your heroku git repo.

The app should be working now.

---

**Note**:  you can get a hosted mongodb via various mongo addons (**heroku addons:add mongohq -a snorkelista**, for example)
**Note-2**: the default config does not lock down the snorkel API which it probably should if used in any serious production environment.
