### PR TITLE
Add support in mongodb for choosing any integer field as the 'time' field

### DIFF
--- a/snorkel/app/client/views/helpers.js
+++ b/snorkel/app/client/views/helpers.js
@@ -413,6 +413,7 @@ var INPUTS = {
   STACKING: [ "stacking" ],
   SORT: [ "sort_by" ],
   TIME_BUCKET: [ "time_bucket" ],
+  TIME_FIELD: [ "time_field" ],
   HIST_BUCKET: [ "hist_bucket" ],
   COMPARE: ["compare"],
   TWO_FIELDS: [

--- a/snorkel/app/client/views/time_view.js
+++ b/snorkel/app/client/views/time_view.js
@@ -267,6 +267,7 @@ var TimeView = BaseView.extend({
 jank.trigger("view:add", "time",  {
     include: helpers.STD_INPUTS
       .concat(helpers.inputs.TIME_BUCKET)
+      .concat(helpers.inputs.TIME_FIELD)
       .concat(helpers.inputs.COMPARE)
       .concat(helpers.inputs.SORT_BY),
     icon: "noun/line.svg"

--- a/snorkel/app/controllers/query/server.js
+++ b/snorkel/app/controllers/query/server.js
@@ -85,6 +85,7 @@ function marshall_query(form_data) {
   query_data.dims = array_of(form_data, 'group_by', ["browser"]);
   query_data.view = value_of(form_data, 'view', 'overview');
   query_data.baseview = value_of(form_data, 'baseview', query_data.view);
+  query_data.time_field = value_of(form_data, 'time_field', 'time');
 
   var limit = 100;
   if (query_data.view === 'samples') {

--- a/snorkel/app/controllers/query/view.js
+++ b/snorkel/app/controllers/query/view.js
@@ -217,6 +217,17 @@ var time_bucket_opts = {
   "daily" : 24 * 60 * 60
 };
 
+function get_time_field_input(cols) {
+  _.each(cols, function (cc) { console.log('*** selection: ', cc.name, cc.display_name); });
+  var integer_names = {};
+  _.each(cols, function (cc) { integer_names[cc.name] = cc.display_name || cc.name; });
+  var field_selector = $C("selector", {
+    name: 'time_field',
+    options: integer_names
+  });
+  return add_control('time_field', 'Time Field', field_selector.toString());
+}
+
 function get_time_bucket_row() {
   var opts = _.invert(time_bucket_opts);
   var max_results_input = $C("selector", { name: "time_bucket", options: opts });
@@ -330,6 +341,9 @@ function get_controls(columns) {
     return col.final_type === SET_TYPE && col.hidden !== 'true';
   });
 
+  var time_field_columns = _.filter(columns, function (col) {
+    return col.final_type == AGGREGABLE_TYPE && col.hidden !== 'true';
+  });
 
   var table_row = get_table_row();
   table_row.addClass("visible-phone");
@@ -338,7 +352,7 @@ function get_controls(columns) {
   control_box.append(get_view_selector_row());
 
   control_box.append(get_time_inputs());
-
+  control_box.append(get_time_field_input(time_field_columns));
   control_box.append($("<div id='rollup' style='position: relative; top: -40px'>"));
   control_box.append(get_group_by_row(groupable_columns));
   control_box.append(get_sort_by_row(agg_columns));


### PR DESCRIPTION
Yo, check this out and LMK what you think (feel free to not take it if this doesn't fit your general direction).  I needed this change (a lot of the user actions records have other <time> fields, most importantly createdTime -- now I can view if there are user behavior changes over time by plotting actions against created time).  I could have split the actions out but this is easier..

Ideally though, it would be nice if the views were a bit more decomposed into specifying x-axis and y-axis independently (i.e. I should be able to specify any integer field as X-axis, I should be able to specify any integer field for the aggregation, I should be able to specify any set of fields for the Y-axis -- non-integer fields should be grouped and integer fields should be bucketed).  Thinking in these terms, the fields can also take simple functions (i.e. log(time) can be the X axis in which case the bucket is applied on the log too). 
