### PR TITLE
Update repository link.

### DIFF
--- a/snorkel/app/static/templates/partials/about/fork_me.html.erb
+++ b/snorkel/app/static/templates/partials/about/fork_me.html.erb
@@ -1,4 +1,4 @@
-<a href="https://github.com/logicflower/snorkel.sf"><img style="position: absolute; top: 50px; right:
+<a href="https://github.com/logv/snorkel"><img style="position: absolute; top: 50px; right:
 0; border: 0; z-index: 10"
 src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
 alt="Fork me on GitHub"></a>


### PR DESCRIPTION
The repository moved and changed names. Use the new name to avoid the GitHub redirect.