### PR TITLE
Fix endless loop when mongo is used as backend

### DIFF
--- a/snorkel/app/controllers/datasets/server.js
+++ b/snorkel/app/controllers/datasets/server.js
@@ -84,8 +84,10 @@ function render_datasets() {
         var table_name = metadata_.name.table_name || metadata_.name;
         var dataset_tokens = table_name.split(backend.SEPARATOR);
         var display_name = metadata_.display_name || dataset_tokens.join("/");
-        while (display_name.indexOf(backend.SEPARATOR) >= 0) {
-          display_name = display_name.replace(backend.SEPARATOR, "/");
+        if (backend.SEPARATOR != "/") {
+          while (display_name.indexOf(backend.SEPARATOR) >= 0) {
+            display_name = display_name.replace(backend.SEPARATOR, "/");
+          }
         }
 
         found_data[table_name] = metadata_;


### PR DESCRIPTION
When mongo is used as backend then code to compute display_name for table enters into an endless loop. The reason is that in mongo backend.SEPARATOR is set to '/'. This caues noop as essentially replace statement looks like this,

`display_name.replace("/", "/");`